### PR TITLE
Added unit angstrom

### DIFF
--- a/length_units.go
+++ b/length_units.go
@@ -22,15 +22,17 @@ var (
 	FemtoMeter = Femto(Meter)
 	AttoMeter  = Atto(Meter)
 
-	Inch    = NewUnit("inch", "in", Length, BI, UnitOptionPlural("inches"))
-	Foot    = NewUnit("foot", "ft", Length, BI, UnitOptionPlural("feet"))
-	Yard    = NewUnit("yard", "yd", Length, BI)
-	Mile    = NewUnit("mile", "", Length, BI)
-	League  = NewUnit("league", "lea", Length, BI)
-	Furlong = NewUnit("furlong", "fur", Length, BI)
+	Angstrom = NewUnit("angstrom", "Å", Length, BI, UnitOptionPlural("angstroms"))
+	Inch     = NewUnit("inch", "in", Length, BI, UnitOptionPlural("inches"))
+	Foot     = NewUnit("foot", "ft", Length, BI, UnitOptionPlural("feet"))
+	Yard     = NewUnit("yard", "yd", Length, BI)
+	Mile     = NewUnit("mile", "", Length, BI)
+	League   = NewUnit("league", "lea", Length, BI)
+	Furlong  = NewUnit("furlong", "fur", Length, BI)
 )
 
 func init() {
+	NewRatioConversion(Angstrom, Meter, 0.0000000001)
 	NewRatioConversion(Inch, Meter, 0.0254)
 	NewRatioConversion(Foot, Meter, 0.3048)
 	NewRatioConversion(Yard, Meter, 0.9144)


### PR DESCRIPTION
    Angstrom is a unit usually used to express molecule or atomic
    sizes. 1Å = 10E-10 m.

    closes bcicen/xiny#4