### PR TITLE
Optimizations

### DIFF
--- a/conversion_valuate.go
+++ b/conversion_valuate.go
@@ -1,0 +1,27 @@
+//+build !novaluate
+
+package units
+
+import "github.com/Knetic/govaluate"
+
+// NewConversion registers a new conversion formula from one Unit to another
+func NewConversion(from, to Unit, formula string) {
+	expr, err := govaluate.NewEvaluableExpression(formula)
+	if err != nil {
+		panic(err)
+	}
+
+	// create conversion function
+	fn := func(x float64) float64 {
+		params := make(map[string]interface{})
+		params["x"] = x
+
+		res, err := expr.Evaluate(params)
+		if err != nil {
+			panic(err)
+		}
+		return res.(float64)
+	}
+
+	NewConversionFromFn(from, to, fn, formula)
+}

--- a/main.go
+++ b/main.go
@@ -1,7 +1,7 @@
 package units
 
 import (
-	"fmt"
+	"errors"
 	"strings"
 )
 
@@ -55,8 +55,7 @@ func Find(s string) (Unit, error) {
 
 	// finally, try stripping plural suffix
 	if strings.HasSuffix(s, "s") || strings.HasSuffix(s, "S") {
-		s = strings.TrimSuffix(s, "s")
-		s = strings.TrimSuffix(s, "S")
+		s = s[:len(s)-1]
 		for _, u := range unitMap {
 			if matchUnit(s, u, false) {
 				return u, nil
@@ -64,7 +63,7 @@ func Find(s string) (Unit, error) {
 		}
 	}
 
-	return Unit{}, fmt.Errorf("unit \"%s\" not found", s)
+	return Unit{}, errors.New("unit \""+ s + "\" not found")
 }
 
 func matchUnit(s string, u Unit, matchCase bool) bool {

--- a/main_test.go
+++ b/main_test.go
@@ -2,13 +2,11 @@ package units
 
 import (
 	"testing"
-
-	"github.com/bcicen/go-units"
 )
 
 // aggregate all unit names, aliases, etc
 func aggrNames() (a []string) {
-	for _, u := range units.All() {
+	for _, u := range All() {
 		for _, name := range u.Names() {
 			a = append(a, name)
 		}
@@ -17,12 +15,12 @@ func aggrNames() (a []string) {
 }
 
 // aggregate units by quantity
-func aggrByQuantity() map[string][]units.Unit {
-	m := make(map[string][]units.Unit)
+func aggrByQuantity() map[string][]Unit {
+	m := make(map[string][]Unit)
 
-	for _, u := range units.All() {
+	for _, u := range All() {
 		if _, ok := m[u.Quantity]; !ok {
-			m[u.Quantity] = []units.Unit{}
+			m[u.Quantity] = []Unit{}
 		}
 		m[u.Quantity] = append(m[u.Quantity], u)
 	}
@@ -32,7 +30,7 @@ func aggrByQuantity() map[string][]units.Unit {
 
 func TestUnitLookup(t *testing.T) {
 	for _, name := range aggrNames() {
-		u, err := units.Find(name)
+		u, err := Find(name)
 		if err != nil {
 			t.Errorf(err.Error())
 			continue
@@ -42,7 +40,7 @@ func TestUnitLookup(t *testing.T) {
 }
 
 func TestUnitNameOverlap(t *testing.T) {
-	nameMap := make(map[string]units.Unit)
+	nameMap := make(map[string]Unit)
 
 	var total, failed int
 	for _, u := range nameMap {
@@ -65,7 +63,7 @@ func TestPathResolve(t *testing.T) {
 	for qname, qunits := range aggrByQuantity() {
 		t.Logf("testing conversion paths for quantity: %s", qname)
 		for _, u1 := range qunits {
-			v1 := units.NewValue(1.0, u1)
+			v1 := NewValue(1.0, u1)
 			for _, u2 := range qunits {
 				if u1.Name == u2.Name {
 					continue

--- a/metric.go
+++ b/metric.go
@@ -1,7 +1,6 @@
 package units
 
 import (
-	"fmt"
 	"math"
 )
 
@@ -51,15 +50,15 @@ func Atto(b Unit, o ...UnitOption) Unit  { return mags["atto"].makeUnit(b, o...)
 
 // Create magnitude unit and conversion given a base unit
 func (mag magnitude) makeUnit(base Unit, addOpts ...UnitOption) Unit {
-	name := fmt.Sprintf("%s%s", mag.Prefix, base.Name)
-	symbol := fmt.Sprintf("%s%s", mag.Symbol, base.Symbol)
+	name := mag.Prefix + base.Name
+	symbol := mag.Symbol + base.Symbol
 
 	// set system to metric by default
 	opts := []UnitOption{SI}
 
 	// create prefixed aliases if needed
 	for _, alias := range base.aliases {
-		magAlias := fmt.Sprintf("%s%s", mag.Prefix, alias)
+		magAlias := mag.Prefix + alias
 		opts = append(opts, UnitOptionAliases(magAlias))
 	}
 

--- a/temp_units.go
+++ b/temp_units.go
@@ -9,8 +9,16 @@ var (
 )
 
 func init() {
-	NewConversion(Celsius, Fahrenheit, "x * 1.8 + 32")
-	NewConversion(Fahrenheit, Celsius, "(x - 32) / 1.8")
-	NewConversion(Celsius, Kelvin, "x + 273.15")
-	NewConversion(Kelvin, Celsius, "x - 273.15")
+	NewConversionFromFn(Celsius, Fahrenheit, func(x float64) float64 {
+		return x * 1.8 + 32
+	}, "x * 1.8 + 32")
+	NewConversionFromFn(Fahrenheit, Celsius, func(x float64) float64 {
+		return (x - 32) / 1.8
+	}, "(x - 32) / 1.8")
+	NewConversionFromFn(Celsius, Kelvin, func(x float64) float64 {
+		return x + 273.15
+	}, "x + 273.15")
+	NewConversionFromFn(Kelvin, Celsius, func(x float64) float64 {
+		return x - 273.15
+	}, "x - 273.15")
 }

--- a/unit.go
+++ b/unit.go
@@ -1,9 +1,5 @@
 package units
 
-import (
-	"fmt"
-)
-
 var (
 	// Shorthand for pre-defined unit systems
 	BI = UnitOptionSystem("imperial")
@@ -25,7 +21,7 @@ type Unit struct {
 // NewUnit registers a new Unit within the package, returning the newly created Unit
 func NewUnit(name, symbol string, opts ...UnitOption) Unit {
 	if _, ok := unitMap[name]; ok {
-		panic(fmt.Errorf("duplicate unit name: %s", name))
+		panic(errors.New("duplicate unit name: %s", name))
 	}
 
 	u := Unit{
@@ -63,7 +59,7 @@ func (u Unit) PluralName() string {
 	case "none":
 		return u.Name
 	case "auto":
-		return fmt.Sprintf("%ss", u.Name)
+		return u.Name + "s"
 	default: // custom plural name
 		return u.plural
 	}

--- a/unit.go
+++ b/unit.go
@@ -1,5 +1,7 @@
 package units
 
+import "errors"
+
 var (
 	// Shorthand for pre-defined unit systems
 	BI = UnitOptionSystem("imperial")
@@ -21,7 +23,7 @@ type Unit struct {
 // NewUnit registers a new Unit within the package, returning the newly created Unit
 func NewUnit(name, symbol string, opts ...UnitOption) Unit {
 	if _, ok := unitMap[name]; ok {
-		panic(errors.New("duplicate unit name: %s", name))
+		panic(errors.New("duplicate unit name: " + name))
 	}
 
 	u := Unit{

--- a/value.go
+++ b/value.go
@@ -1,7 +1,6 @@
 package units
 
 import (
-	"fmt"
 	"math"
 	"strconv"
 	"strings"
@@ -51,7 +50,7 @@ func (v Value) Fmt(opts FmtOptions) string {
 	if !opts.Label {
 		return vstr
 	}
-	return fmt.Sprintf("%s %s", vstr, label)
+	return vstr + " " + label
 }
 
 // MustConvert converts this Value to another Unit, panicking on error


### PR DESCRIPTION
[Knetic/govaluate](https://github.com/Knetic/govaluate) is no longer needed for initialization and can be excluded if the `novaluate` build tag is supplied. But if you aren't explicitly specifying that tag there are no incompatible changes to the API. Only `func NewConversionFromFn(from, to Unit, f ConversionFn, formula string)` is added. This should cut down initialization time by 'evaluating' the formulas on compile time.

Various smaller optimizations:
- replace fmt.Sprintf with string concatenation (1/3 allocations; 1/6 execution time)
- replace fmt.Errorf with errors.New (see effects of removing Sprintf above)
- extracted fmtFormula.re to global scope (compile regexp just once)
- replaced calls to strings.TrimSuffix with single slice operations (otherwise strings.HasSuffix calls would be duplicated) 