### PR TITLE
Liters should be labeled as SI units

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,8 @@ module github.com/bcicen/go-units
 
 go 1.13
 
-require github.com/bcicen/bfstree v0.0.0-20180121191807-11ea469698a6
+require (
+	github.com/Knetic/govaluate v3.0.0+incompatible
+	github.com/bcicen/bfstree v0.0.0-20180121191807-11ea469698a6
+	github.com/stretchr/testify v1.5.1
+)

--- a/volume_units.go
+++ b/volume_units.go
@@ -4,7 +4,7 @@ var (
 	Volume = UnitOptionQuantity("volume")
 
 	// metric
-	Liter      = NewUnit("liter", "l", Volume, UnitOptionAliases("litre"))
+	Liter      = NewUnit("liter", "l", Volume, SI, UnitOptionAliases("litre"))
 	ExaLiter   = Exa(Liter)
 	PetaLiter  = Peta(Liter)
 	TeraLiter  = Tera(Liter)

--- a/volume_units_test.go
+++ b/volume_units_test.go
@@ -1,0 +1,39 @@
+package units
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestVolumeSystems(t *testing.T) {
+	SI := "metric"
+	assert.Equal(t, SI, Liter.System())
+	assert.Equal(t, SI, ExaLiter.System())
+	assert.Equal(t, SI, PetaLiter.System())
+	assert.Equal(t, SI, TeraLiter.System())
+	assert.Equal(t, SI, GigaLiter.System())
+	assert.Equal(t, SI, MegaLiter.System())
+	assert.Equal(t, SI, KiloLiter.System())
+	assert.Equal(t, SI, HectoLiter.System())
+	assert.Equal(t, SI, DecaLiter.System())
+	assert.Equal(t, SI, DeciLiter.System())
+	assert.Equal(t, SI, CentiLiter.System())
+	assert.Equal(t, SI, MilliLiter.System())
+	assert.Equal(t, SI, MicroLiter.System())
+	assert.Equal(t, SI, NanoLiter.System())
+	assert.Equal(t, SI, PicoLiter.System())
+	assert.Equal(t, SI, FemtoLiter.System())
+	assert.Equal(t, SI, AttoLiter.System())
+
+	BI := "imperial"
+	assert.Equal(t, BI, Quart.System())
+	assert.Equal(t, BI, Pint.System())
+	assert.Equal(t, BI, Gallon.System())
+	assert.Equal(t, BI, FluidOunce.System())
+
+	US := "us"
+	assert.Equal(t, US, FluidQuart.System())
+	assert.Equal(t, US, FluidPint.System())
+	assert.Equal(t, US, FluidGallon.System())
+	assert.Equal(t, US, CustomaryFluidOunce.System())
+}


### PR DESCRIPTION

Liters (and all other permutations of) are not currently labeled as part of the SI/metric system. They simply return an empty string; [see this example](https://play.golang.org/p/qKFcDcsL0uZ). This PR fixes that.

### Changes
* Added SI `UnitOptionSystem` for Liters.
* Added a test case to validate the 'system' for all volume units.  Let me know if I missed a more logical location for these tests.  I can alter as you see fit.
* Added `github.com/stretchr/testify` as a dependency for the test case.  I would understand if you do not want to add this net-new dependency for your project.  I can alter as you see fit.