### PR TITLE
Some trivial cleanups

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -7,9 +7,7 @@ import (
 // aggregate all unit names, aliases, etc
 func aggrNames() (a []string) {
 	for _, u := range All() {
-		for _, name := range u.Names() {
-			a = append(a, name)
-		}
+		a = append(a, u.Names()...)
 	}
 	return a
 }

--- a/metric.go
+++ b/metric.go
@@ -11,22 +11,22 @@ type magnitude struct {
 }
 
 var mags = map[string]magnitude{
-	"exa":   magnitude{"E", "exa", 18.0},
-	"peta":  magnitude{"P", "peta", 15.0},
-	"tera":  magnitude{"T", "tera", 12.0},
-	"giga":  magnitude{"G", "giga", 9.0},
-	"mega":  magnitude{"M", "mega", 6.0},
-	"kilo":  magnitude{"k", "kilo", 3.0},
-	"hecto": magnitude{"h", "hecto", 2.0},
-	"deca":  magnitude{"da", "deca", 1.0},
-	"deci":  magnitude{"d", "deci", -1.0},
-	"centi": magnitude{"c", "centi", -2.0},
-	"milli": magnitude{"m", "milli", -3.0},
-	"micro": magnitude{"μ", "micro", -6.0},
-	"nano":  magnitude{"n", "nano", -9.0},
-	"pico":  magnitude{"p", "pico", -12.0},
-	"femto": magnitude{"f", "femto", -15.0},
-	"atto":  magnitude{"a", "atto", -18.0},
+	"exa":   {"E", "exa", 18.0},
+	"peta":  {"P", "peta", 15.0},
+	"tera":  {"T", "tera", 12.0},
+	"giga":  {"G", "giga", 9.0},
+	"mega":  {"M", "mega", 6.0},
+	"kilo":  {"k", "kilo", 3.0},
+	"hecto": {"h", "hecto", 2.0},
+	"deca":  {"da", "deca", 1.0},
+	"deci":  {"d", "deci", -1.0},
+	"centi": {"c", "centi", -2.0},
+	"milli": {"m", "milli", -3.0},
+	"micro": {"μ", "micro", -6.0},
+	"nano":  {"n", "nano", -9.0},
+	"pico":  {"p", "pico", -12.0},
+	"femto": {"f", "femto", -15.0},
+	"atto":  {"a", "atto", -18.0},
 }
 
 // Magnitude prefix methods create and return a new Unit, while automatically registering

--- a/metric.go
+++ b/metric.go
@@ -63,9 +63,7 @@ func (mag magnitude) makeUnit(base Unit, addOpts ...UnitOption) Unit {
 	}
 
 	// append any supplmental options
-	for _, opt := range addOpts {
-		opts = append(opts, opt)
-	}
+	opts = append(opts, addOpts...)
 
 	// append quantity name opt
 	opts = append(opts, UnitOptionQuantity(base.Quantity))

--- a/metric_test.go
+++ b/metric_test.go
@@ -2,6 +2,8 @@ package units
 
 import (
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 var magNames = []string{
@@ -27,8 +29,9 @@ type magFn func(Unit, ...UnitOption) Unit
 
 func TestMagnitudes(t *testing.T) {
 	u := NewUnit("dong", "₫")
-	for _, mfn := range []magFn{Exa, Peta, Tera, Giga, Mega, Kilo, Hecto, Deca, Deci, Centi, Milli, Micro, Nano, Pico, Femto, Atto} {
+	for i, mfn := range []magFn{Exa, Peta, Tera, Giga, Mega, Kilo, Hecto, Deca, Deci, Centi, Milli, Micro, Nano, Pico, Femto, Atto} {
 		mu := mfn(u)
 		t.Logf("created mag unit: %s (%s)", mu.Name, mu.Symbol)
+		assert.Equal(t, mu.Name, magNames[i]+"dong")
 	}
 }

--- a/unit.go
+++ b/unit.go
@@ -84,9 +84,7 @@ func UnitOptionPlural(s string) UnitOption {
 // Additional names, spellings, or symbols that this unit may be referred to as
 func UnitOptionAliases(a ...string) UnitOption {
 	return func(u Unit) Unit {
-		for _, s := range a {
-			u.aliases = append(u.aliases, s)
-		}
+		u.aliases = append(u.aliases, a...)
 		return u
 	}
 }


### PR DESCRIPTION
Here are three trivial cleanups revealed by `golangci-lint`:

* Simplify literal definition of the map of magnitudes
* Simplify a couple of trivial append loops
* Actually use the `magNames` definition in the magnitude test