### PR TITLE
Ensure that Find() has consistent results by always iterating through a sorted list of units

### DIFF
--- a/units.go
+++ b/units.go
@@ -42,16 +42,17 @@ func ConvertFloat(x float64, from, to Unit) (Value, error) {
 
 // Find Unit matching name or symbol provided
 func Find(s string) (Unit, error) {
+	allUnits := All()
 
 	// first try case-sensitive match
-	for _, u := range unitMap {
+	for _, u := range allUnits {
 		if matchUnit(s, u, true) {
 			return u, nil
 		}
 	}
 
 	// then case-insensitive
-	for _, u := range unitMap {
+	for _, u := range allUnits {
 		if matchUnit(s, u, false) {
 			return u, nil
 		}

--- a/units_test.go
+++ b/units_test.go
@@ -2,6 +2,8 @@ package units
 
 import (
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 // aggregate all unit names, aliases, etc
@@ -53,6 +55,21 @@ func TestUnitNameOverlap(t *testing.T) {
 		}
 	}
 	t.Logf("tested %d unit names, %d overlaps", total, failed)
+}
+
+func TestSimilarSymbolLookup(t *testing.T) {
+	// The casing of gb could match both gigabyte (GB) and gigabit (Gb)
+	symbol := "gb"
+
+	// Run the same assertion multiple times to ensure there is no inconsistency to the results based on random map ordering
+	for range make([]bool, 100) {
+		u, err := Find(symbol)
+		if err != nil {
+			t.Errorf("failed to find unit for symbol %s", symbol)
+		}
+		
+		assert.Equal(t, GigaBit, u)
+	}
 }
 
 // ensure all units within the same quantity resolve


### PR DESCRIPTION
When attempting to find a unit with an imperfectly-cased symbol that could match multiple registered units (e.g. `gB` could match `GB` or `Gb`) it would be helpful to ensure that the results of `Find()` are consistent across multiple calls. Currently, since `Find()` searches through the `unitMap` it will be random whether `GB` or `Gb` will be found first and this could lead users to think their code works when in fact it's flaky. This change switches `unitMap` for `All()` which is a sorted slice and will provide consistent results.