### PR TITLE
add speed units

### DIFF
--- a/speed.go
+++ b/speed.go
@@ -1,0 +1,18 @@
+package units
+
+var (
+	Speed = UnitOptionQuantity("speed")
+
+	MetersPerSecond   = NewUnit("meter per second", "m/s", Speed, SI, UnitOptionPlural("meters per second"))
+	MetersPerHour     = NewUnit("meter per hour", "m/h", Speed, SI, UnitOptionPlural("meters per hour"))
+	KilometersPerHour = NewUnit("kilometer per hour", "km/h", Speed, SI, UnitOptionPlural("kilometers per hour"))
+	MilesPerHour      = NewUnit("mile per hour", "mph", Speed, BI, UnitOptionPlural("miles per hour"))
+	Knot              = NewUnit("knot", "kn", Speed, BI, UnitOptionAliases("nautical miles per hour"))
+)
+
+func init() {
+	NewRatioConversion(MetersPerSecond, KilometersPerHour, 3.6)
+	NewRatioConversion(MetersPerSecond, MetersPerHour, 3600)
+	NewRatioConversion(MilesPerHour, KilometersPerHour, 1.609344)
+	NewRatioConversion(Knot, KilometersPerHour, 1.852)
+}


### PR DESCRIPTION
This pr corresponds to https://github.com/bcicen/go-units/issues/33

The conversion multipliers are a bit confusing, but I wanted to have accurate conversions (see https://en.wikipedia.org/wiki/Knot_(unit)).